### PR TITLE
atop: break version schema

### DIFF
--- a/.github/workflows/check-apk-valid-version.yml
+++ b/.github/workflows/check-apk-valid-version.yml
@@ -1,0 +1,98 @@
+name: Check APK compatible version/release
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, converted_to_draft, ready_for_review, edited]
+
+jobs:
+  build:
+    name: Check autorelease deprecation
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Determine branch name
+        run: |
+          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          echo "Building for $BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Determine changed packages
+        run: |
+          RET=0
+          INCOMPATIBLE_VERSION=""
+
+          # only detect packages with changes
+          PKG_ROOTS=$(find . -name Makefile | \
+            grep -v ".*/src/Makefile" | \
+            sed -e 's@./\(.*\)/Makefile@\1/@')
+          CHANGES=$(git diff --diff-filter=d --name-only origin/$BRANCH...)
+
+          for ROOT in $PKG_ROOTS; do
+            for CHANGE in $CHANGES; do
+              if [[ "$CHANGE" == "$ROOT"* ]]; then
+                PKG_RELEASE=$(grep -E '^PKG_RELEASE' "$ROOT/Makefile" | cut -f 2 -d '=')
+                if [ -n "$PKG_RELEASE" ]; then
+                  if [[ "$PKG_RELEASE" == '^[0-9]+$' ]]; then
+                    INCOMPATIBLE_VERSION+="$ROOT"
+                    break
+                  fi
+                fi
+                PKG_VERSION=$(grep -E '^PKG_VERSION' "$ROOT/Makefile" | cut -f 2 -d '=')
+                if [ -n "$PKG_VERSION" ]; then
+                  if /Users/user/src/openwrt/apk-tools/build/src/apk version --check "$PKG_VERSION"; then
+                    INCOMPATIBLE_VERSION+="$ROOT"
+                  fi
+                fi
+              fi
+            done
+          done
+
+          echo "Incompatible versions: $INCOMPATIBLE_VERSION"
+
+          if [ -n "$INCOMPATIBLE_VERSION" ]; then
+            RET=1
+            cat > "$GITHUB_WORKSPACE/pr_comment.md" << EOF
+          OpenWrt will change to the APK package manager which requires
+          deterministic verisons. Please make sure that **PKG_VERSION**
+          follows [Semantic Versioning](https://semver.org) or more specifically,
+          the [APK version scheme](https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/doc/apk-package.5.scd?ref_type=heads#L47).
+          If the version is based on a date, please use dots instead of dashes, i.e. **24.01.01**.
+
+          The **PKG_RELEASE** should be an integer and not contain any letters or special characters.
+
+          EOF
+
+          fi
+
+          for ROOT in $INCOMPATIBLE_VERSION; do
+            echo "  - ${ROOT}/Makefile" >> "$GITHUB_WORKSPACE/pr_comment.md"
+          done
+
+          exit $RET
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        if: ${{ failure() }}
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v2
+        if: ${{ failure() }}
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-file: "pr_comment.md"
+          edit-mode: replace

--- a/admin/atop/Makefile
+++ b/admin/atop/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atop
 PKG_RELEASE:=1
-PKG_VERSION:=2.7.1
+PKG_VERSION:=2.7.1x
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.atoptool.nl/download/


### PR DESCRIPTION
Just for testing

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
